### PR TITLE
swap order of arguments in .join()

### DIFF
--- a/components/RbacManager.php
+++ b/components/RbacManager.php
@@ -353,7 +353,7 @@ class RbacManager extends \yii\base\Component {
 		$user = \Yii::$app->user->getIdentity();
 
 		if ($user) {
-			$this->log("Found user ".$user->id." with roles: ".join($this->getUserRoles($user),", "), __METHOD__,true);
+			$this->log("Found user ".$user->id." with roles: ".join(", ",$this->getUserRoles($user)), __METHOD__,true);
 
 			// Initialise roles with defaults plus registered user roles
 			$this->userRoles = array_merge($this->defaultUserRoles, $this->registeredUserRoles);


### PR DESCRIPTION
I was encountering a login error. Swapping the order of the arguments order in .join() , fixed this error:

```
"yii\base\ErrorException: join(): Passing glue string after array is deprecated. Swap the parameters in /path/to/app/vendor/mozzler/yii2-rbac/components/RbacManager.php:356 Stack trace:
#0 [internal function]: yii\base\ErrorHandler->handleError(8192, 'join(): Passing...', '/Users/michal/d...', 356, Array) 
#1 /path/to/app/vendor/mozzler/yii2-rbac/components/RbacManager.php(356): join(Array, ', ') 
#2 [internal function]: mozzler\rbac\components\RbacManager->initRoles(Object(yii\web\UserEvent)) 
#3 /path/to/app/vendor/yiisoft/yii2/base/Component.php(627): call_user_func(Array, Object(yii\web\UserEvent)) 
#4 /path/to/app/vendor/yiisoft/yii2/web/User.php(495): yii\base\Component->trigger('afterLogin', Object(yii\web\UserEvent)) 
#5 /path/to/app/vendor/yiisoft/yii2/web/User.php(264): yii\web\User->afterLogin(Object(app\models\User), false, 0) 
#6 /path/to/app/vendor/yiisoft/yii2/web/User.php(299): yii\web\User->login(Object(app\models\User)) 
#7 /path/to/app/vendor/yiisoft/yii2/filters/auth/HttpHeaderAuth.php(62): yii\web\User->loginByAccessToken('ca3bc29d689aa49...', 'mozzler\\auth\\yi...') 
#8 /path/to/app/vendor/yiisoft/yii2/filters/auth/CompositeAuth.php(73): yii\filters\auth\HttpHeaderAuth->authenticate(Object(yii\web\User), Object(yii\web\Request), Object(yii\web\Response)) 
#9 /path/to/app/vendor/yiisoft/yii2/filters/auth/AuthMethod.php(59): yii\filters\auth\CompositeAuth->authenticate(Object(yii\web\User), Object(yii\web\Request), Object(yii\web\Response)) 
#10 /path/to/app/vendor/yiisoft/yii2/filters/auth/CompositeAuth.php(57): yii\filters\auth\AuthMethod->beforeAction(Object(mozzler\base\actions\ActiveViewAction)) 
#11 /path/to/app/vendor/mozzler/yii2-auth/yii/oauth/auth/CompositeAuth.php(19): yii\filters\auth\CompositeAuth->beforeAction(Object(mozzler\base\actions\ActiveViewAction)) 
#12 /path/to/app/vendor/yiisoft/yii2/base/ActionFilter.php(77): mozzler\auth\yii\oauth\auth\CompositeAuth->beforeAction(Object(mozzler\base\actions\ActiveViewAction)) 
#13 [internal function]: yii\base\ActionFilter->beforeFilter(Object(yii\base\ActionEvent)) 
#14 /path/to/app/vendor/yiisoft/yii2/base/Component.php(627): call_user_func(Array, Object(yii\base\ActionEvent)) 
#15 /path/to/app/vendor/yiisoft/yii2/base/Controller.php(276): yii\base\Component->trigger('beforeAction', Object(yii\base\ActionEvent)) 
#16 /path/to/app/vendor/yiisoft/yii2/web/Controller.php(164): yii\base\Controller->beforeAction(Object(mozzler\base\actions\ActiveViewAction)) 
#17 /path/to/app/vendor/yiisoft/yii2/base/Controller.php(155): yii\web\Controller->beforeAction(Object(mozzler\base\actions\ActiveViewAction)) 
#18 /path/to/app/vendor/yiisoft/yii2/base/Module.php(528): yii\base\Controller->runAction('view', Array) 
#19 /path/to/app/vendor/yiisoft/yii2/web/Application.php(103): yii\base\Module->runAction('v1/user/view', Array) 
#20 /path/to/app/vendor/yiisoft/yii2/base/Application.php(386): yii\web\Application->handleRequest(Object(yii\web\Request)) 
#21 /path/to/app/web/index.php(12): yii\base\Application->run() 
#22 {main}";i:1;i:1;i:2;s:28:"yii\base\ErrorException:8192"
```